### PR TITLE
Flexible Iconography and Button list item type

### DIFF
--- a/Source_code/astra_ui_drawer.c
+++ b/Source_code/astra_ui_drawer.c
@@ -161,7 +161,7 @@ void astra_draw_info_bar()
                   (int16_t)astra_info_bar.w_info_bar, INFO_BAR_HEIGHT + 4, 3);
   //向上移动四个像素 同时向下多画四个像素 只用下半部分圆角
 
-  oled_set_draw_color(2);
+  oled_set_draw_color(0);
   oled_draw_H_line(_x_info_bar + 2, _y_info_bar_2 - 2, (int16_t)(astra_info_bar.w_info_bar - 4));
   oled_draw_pixel(_x_info_bar + 1, _y_info_bar_2 - 3);
   oled_draw_pixel(_x_info_bar - 2, _y_info_bar_2 - 3);
@@ -203,7 +203,7 @@ void astra_draw_pop_up()
                   (int16_t)(astra_pop_up.w_pop_up + 4),
                   POP_UP_HEIGHT, 3);
 
-  oled_set_draw_color(2);
+  oled_set_draw_color(0);
   oled_draw_H_line(_x_pop_up, _y_pop_up - 2, (int16_t)astra_pop_up.w_pop_up);
   oled_draw_pixel(_x_pop_up - 1, _y_pop_up - 3);
   oled_draw_pixel((int16_t)(OLED_WIDTH/2 + astra_pop_up.w_pop_up/2), _y_pop_up - 3);
@@ -287,9 +287,7 @@ void astra_draw_list_item()
     {
       if (_y_list_item + 2 > LIST_INFO_BAR_HEIGHT && _y_list_item - 2 < SCREEN_HEIGHT)
       {
-        oled_draw_H_line(2 + _x_list_item, _y_list_item - 2, 4);
-        oled_draw_H_line(2 + _x_list_item, _y_list_item, 5);
-        oled_draw_H_line(2 + _x_list_item, _y_list_item + 2, 3);
+        astra_draw_list_icon(astra_selector.selected_item->parent->child_list_item[i]->icon, _x_list_item, _y_list_item);        
       }
     } else if (astra_selector.selected_item->parent->child_list_item[i]->type == switch_item)
     {
@@ -299,8 +297,7 @@ void astra_draw_list_item()
 
       if (_y_list_item + 7 > LIST_INFO_BAR_HEIGHT && _y_list_item + 1 < SCREEN_HEIGHT)
       {
-        oled_draw_circle(4 + _x_list_item, _y_list_item + 1, 3);
-        oled_draw_V_line(4 + _x_list_item, _y_list_item, 3);
+        astra_draw_list_icon(astra_selector.selected_item->parent->child_list_item[i]->icon, _x_list_item, _y_list_item);
 
         //开关控件指示器部分
         oled_draw_frame(OLED_WIDTH - LIST_ITEM_RIGHT_MARGIN - 7, _y_list_item - 2, 11, 7);
@@ -315,7 +312,15 @@ void astra_draw_list_item()
           oled_draw_pixel(OLED_WIDTH - LIST_ITEM_RIGHT_MARGIN, _y_list_item + 1);
         }
       }
-    } else if (astra_selector.selected_item->parent->child_list_item[i]->type == slider_item)
+    } else if (astra_selector.selected_item->parent->child_list_item[i]->type == button_item)
+    {
+      astra_button_item_t *_button_item = astra_to_button_item(astra_selector.selected_item->parent->child_list_item[i]);
+      if (_y_list_item + 7 > LIST_INFO_BAR_HEIGHT && _y_list_item + 1 < SCREEN_HEIGHT)
+      {
+        astra_draw_list_icon(astra_selector.selected_item->parent->child_list_item[i]->icon, _x_list_item, _y_list_item);
+      }
+    } 
+    else if (astra_selector.selected_item->parent->child_list_item[i]->type == slider_item)
     {
       astra_slider_item_t *_slider_item = astra_to_slider_item(astra_selector.selected_item->parent->child_list_item[i]);
       if (_slider_item->init_function && astra_refresh_list_value)
@@ -323,14 +328,13 @@ void astra_draw_list_item()
 
       if (_y_list_item + 5 > LIST_INFO_BAR_HEIGHT && _y_list_item - 2 < SCREEN_HEIGHT)
       {
-        oled_draw_V_line(3 + _x_list_item, _y_list_item - 1, 5);
-        oled_draw_V_line(6 + _x_list_item, _y_list_item - 1, 5);
-        oled_draw_box(2 + _x_list_item, _y_list_item - 2, 3, 3);
-        oled_draw_box(5 + _x_list_item, _y_list_item + 2, 3, 3);
+        astra_draw_list_icon(astra_selector.selected_item->parent->child_list_item[i]->icon, _x_list_item, _y_list_item);
 
         //滑块控件指示器部分
         char _value_str[10] = {};
         sprintf(_value_str, "%d", *_slider_item->value);
+
+        int16_t _x_value = OLED_WIDTH - LIST_ITEM_RIGHT_MARGIN - oled_get_str_width(_value_str) + 2;
 
         //如果选中了就闪烁 否则就一直显示
         if (_slider_item->is_confirmed)
@@ -345,7 +349,7 @@ void astra_draw_list_item()
             oled_draw_R_box(_x_value, _y_list_item - 4, oled_get_UTF8_width(_value_str) + 4, oled_get_str_height() - 2, 1);
           }
 
-          oled_set_draw_color(2);
+          oled_set_draw_color(0);
           oled_draw_str(_x_value + 2, _y_list_item + oled_get_str_height() / 2, _value_str);
 
           if (_ticks - _last_tick >= 1000)
@@ -358,7 +362,7 @@ void astra_draw_list_item()
     } else
     {
       if (_y_list_item + oled_get_str_height() / 2 > LIST_INFO_BAR_HEIGHT && _y_list_item + oled_get_str_height() / 2 < SCREEN_HEIGHT)
-        oled_draw_str(2 + _x_list_item, _y_list_item + oled_get_str_height() / 2, "-");
+        astra_draw_list_icon(astra_selector.selected_item->parent->child_list_item[i]->icon, _x_list_item, _y_list_item);
     }
 
     astra_set_font(u8g2_font_my_chinese);
@@ -368,6 +372,48 @@ void astra_draw_list_item()
   }
 
   astra_refresh_list_value = false;
+}
+
+void astra_draw_list_icon(astra_list_item_icon_t icon, uint16_t x, uint16_t y){
+  switch(icon){
+    case (list_icon):
+        oled_draw_H_line(2 + x, y - 2, 4);
+        oled_draw_H_line(2 + x, y, 5);
+        oled_draw_H_line(2 + x, y + 2, 3);
+      break;
+    case (switch_icon):
+        oled_draw_circle(4 + x, y + 1, 3);
+        oled_draw_V_line(4 + x, y, 3);
+      break;
+    case (plus_icon):
+        oled_draw_circle(4 + x, y + 1, 3);
+        oled_draw_V_line(4 + x, y, 3);
+        oled_draw_H_line(3 + x, y + 1, 3);
+      break;
+    case (slider_icon):
+        oled_draw_V_line(3 + x, y - 1, 5);
+        oled_draw_V_line(6 + x, y - 1, 5);
+        oled_draw_box(2 + x, y - 2, 3, 3);
+        oled_draw_box(5 + x, y + 2, 3, 3);
+      break;
+    case (user_icon):
+        oled_draw_str(2 + x, y + oled_get_str_height() / 2, "-");
+      break;
+    case (flag_icon):
+        oled_draw_V_line(6 + x, y - 1, 5);
+        oled_draw_box(3 + x, y - 2, 4, 3);
+      break;
+    case (power_icon):
+        oled_draw_circle(4 + x, y + 1, 3);
+        oled_draw_V_line(4 + x, y - 2, 3);
+        oled_set_draw_color(0);
+        oled_draw_pixel(x+3, y-2);
+        oled_draw_pixel(x+5, y-2);
+        oled_set_draw_color(1);
+      break;
+    default:
+      break;
+  }
 }
 
 void astra_draw_selector()

--- a/Source_code/astra_ui_drawer.h
+++ b/Source_code/astra_ui_drawer.h
@@ -18,6 +18,8 @@ extern void astra_draw_list_appearance();   //前景
 
 extern void astra_draw_list_item();   //背景
 
+extern void astra_draw_list_icon(astra_list_item_icon_t icon, uint16_t x, uint16_t y);
+
 extern void astra_draw_selector();    //背景
 
 extern void astra_draw_widget();    //总的控件 前景

--- a/Source_code/astra_ui_item.c
+++ b/Source_code/astra_ui_item.c
@@ -70,6 +70,14 @@ astra_switch_item_t *astra_to_switch_item(astra_list_item_t *_astra_list_item)
   return (astra_switch_item_t*)astra_get_root_list();
 }
 
+astra_button_item_t *astra_to_button_item(astra_list_item_t *_astra_list_item)
+{
+  if (_astra_list_item != NULL && _astra_list_item->type == button_item)
+    return (astra_button_item_t*)_astra_list_item;
+
+  return (astra_button_item_t*)astra_get_root_list();
+}
+
 astra_slider_item_t *astra_to_slider_item(astra_list_item_t *_astra_list_item)
 {
   if (_astra_list_item != NULL && _astra_list_item->type == slider_item)
@@ -100,16 +108,21 @@ astra_list_item_t *astra_get_root_list()
   return _astra_list_root_item;
 }
 
-astra_list_item_t *astra_new_list_item(char *_content)
+astra_list_item_t *astra_new_list_item(char *_content, astra_list_item_icon_t icon)
 {
   astra_list_item_t *_astra_list_item = malloc(sizeof(astra_list_item_t));
   memset(_astra_list_item, 0, sizeof(astra_list_item_t));
   _astra_list_item->type = list_item;
   _astra_list_item->content = _content;
+  if(icon == default_icon)
+    _astra_list_item->icon = list_icon;
+  else
+    _astra_list_item->icon = icon;
+
   return _astra_list_item;
 }
 
-astra_list_item_t *astra_new_switch_item(char *_content, bool *_value, void (*_init_function)(), void (*_exit_function)())
+astra_list_item_t *astra_new_switch_item(char *_content, bool *_value, void (*_init_function)(), void (*_exit_function)(), astra_list_item_icon_t icon)
 {
   astra_switch_item_t *_astra_switch_item = malloc(sizeof(astra_switch_item_t));
   memset(_astra_switch_item, 0, sizeof(astra_switch_item_t));
@@ -118,10 +131,31 @@ astra_list_item_t *astra_new_switch_item(char *_content, bool *_value, void (*_i
   _astra_switch_item->value = _value;
   _astra_switch_item->init_function = _init_function;
   _astra_switch_item->exit_function = _exit_function;
+  if(icon == default_icon)
+    _astra_switch_item->base_item.icon = switch_icon;
+  else
+    _astra_switch_item->base_item.icon = icon;
+
 return (astra_list_item_t*)_astra_switch_item;
 }
 
-astra_list_item_t *astra_new_slider_item(char *_content, int16_t *_value, uint8_t _step, int16_t _min, int16_t _max, void (*_init_function)(), void (*_exit_function)())
+astra_list_item_t *astra_new_button_item(char *_content, void (*_exit_function)(), astra_list_item_icon_t icon)
+{
+  astra_button_item_t *_astra_button_item = malloc(sizeof(astra_button_item_t));
+  memset(_astra_button_item, 0, sizeof(astra_button_item_t));
+  _astra_button_item->base_item.type = button_item;
+  _astra_button_item->base_item.content = _content;
+  _astra_button_item->exit_function = _exit_function;
+  if(icon == default_icon)
+    _astra_button_item->base_item.icon = plus_icon;
+  else
+    _astra_button_item->base_item.icon = icon;
+
+
+return (astra_list_item_t*)_astra_button_item;
+}
+
+astra_list_item_t *astra_new_slider_item(char *_content, int16_t *_value, uint8_t _step, int16_t _min, int16_t _max, void (*_init_function)(), void (*_exit_function)(), astra_list_item_icon_t icon)
 {
   astra_slider_item_t *_astra_slider_item = malloc(sizeof(astra_slider_item_t));
   memset(_astra_slider_item, 0, sizeof(astra_slider_item_t));
@@ -133,10 +167,15 @@ astra_list_item_t *astra_new_slider_item(char *_content, int16_t *_value, uint8_
   _astra_slider_item->value_max = _max;
   _astra_slider_item->init_function = _init_function;
   _astra_slider_item->exit_function = _exit_function;
+    if(icon == default_icon)
+    _astra_slider_item->base_item.icon = slider_icon;
+  else
+    _astra_slider_item->base_item.icon = icon;
+
 return (astra_list_item_t*)_astra_slider_item;
 }
 
-astra_list_item_t *astra_new_user_item(char *_content, void (*_init_function)(), void (*_loop_function)(), void (*_exit_function)())
+astra_list_item_t *astra_new_user_item(char *_content, void (*_init_function)(), void (*_loop_function)(), void (*_exit_function)(), astra_list_item_icon_t icon)
 {
   astra_user_item_t *_astra_user_item = malloc(sizeof(astra_user_item_t));
   memset(_astra_user_item, 0, sizeof(astra_user_item_t));
@@ -145,6 +184,11 @@ astra_list_item_t *astra_new_user_item(char *_content, void (*_init_function)(),
   _astra_user_item->init_function = _init_function;
   _astra_user_item->loop_function = _loop_function;
   _astra_user_item->exit_function = _exit_function;
+  if(icon == default_icon)
+    _astra_user_item->base_item.icon = user_icon;
+  else
+    _astra_user_item->base_item.icon = icon;
+
   return (astra_list_item_t*)_astra_user_item;  //转换回基类 但保留专有数据
 }
 
@@ -260,6 +304,15 @@ void astra_selector_jump_to_selected_item()
   {
     astra_switch_item_t* _selected_switch_item = astra_to_switch_item(astra_selector.selected_item);
     *_selected_switch_item->value = !*_selected_switch_item->value;
+    if (_selected_switch_item->exit_function)
+      _selected_switch_item->exit_function();
+    return;
+  }
+
+  if (astra_selector.selected_item->type == button_item)
+  {
+    astra_button_item_t* _selected_switch_item = astra_to_button_item(astra_selector.selected_item);
+
     if (_selected_switch_item->exit_function)
       _selected_switch_item->exit_function();
     return;

--- a/Source_code/astra_ui_item.h
+++ b/Source_code/astra_ui_item.h
@@ -71,11 +71,24 @@ typedef enum
   switch_item,
   slider_item,
   user_item,
+  button_item,
 } astra_list_item_type_t;
+
+typedef enum {
+    default_icon,
+    list_icon,
+    switch_icon,
+    plus_icon,
+    user_icon,
+    slider_icon,
+    flag_icon,
+    power_icon,
+} astra_list_item_icon_t;
 
 typedef struct astra_list_item_t
 {
   astra_list_item_type_t type;
+  astra_list_item_icon_t icon;
   char *content;
 
   uint8_t layer;
@@ -93,6 +106,13 @@ typedef struct astra_switch_item_t
   void (*init_function)();
   void (*exit_function)();
 } astra_switch_item_t;
+
+typedef struct astra_button_item_t
+{
+  astra_list_item_t base_item;
+
+  void (*exit_function)();
+} astra_button_item_t;
 
 typedef struct astra_slider_item_t
 {
@@ -125,13 +145,15 @@ typedef struct astra_user_item_t
 extern astra_list_item_t *astra_get_root_list();
 
 extern astra_switch_item_t *astra_to_switch_item(astra_list_item_t *_astra_list_item);
+extern astra_button_item_t *astra_to_button_item(astra_list_item_t *_astra_list_item);
 extern astra_slider_item_t *astra_to_slider_item(astra_list_item_t *_astra_list_item);
 extern astra_user_item_t *astra_to_user_item(astra_list_item_t *_astra_list_item);
-extern astra_list_item_t *astra_new_list_item(char *_content);
+extern astra_list_item_t *astra_new_list_item(char *_content, astra_list_item_icon_t icon);
 //正确用法：astra_push_item_to_list(astra_get_root_list(), astra_new_list_item(...));
-extern astra_list_item_t *astra_new_switch_item(char *_content, bool *_value, void (*_init_function)(), void (*_exit_function)());
-extern astra_list_item_t *astra_new_slider_item(char *_content, int16_t *_value, uint8_t _step, int16_t _min, int16_t _max, void (*_init_function)(), void (*_exit_function)());
-extern astra_list_item_t *astra_new_user_item(char *_content, void (*_init_function)(), void (*_loop_function)(), void (*_exit_function)());
+extern astra_list_item_t *astra_new_switch_item(char *_content, bool *_value, void (*_init_function)(), void (*_exit_function)(), astra_list_item_icon_t icon);
+extern astra_list_item_t *astra_new_button_item(char *_content, void (*_exit_function)(), astra_list_item_icon_t icon);
+extern astra_list_item_t *astra_new_slider_item(char *_content, int16_t *_value, uint8_t _step, int16_t _min, int16_t _max, void (*_init_function)(), void (*_exit_function)(), astra_list_item_icon_t icon);
+extern astra_list_item_t *astra_new_user_item(char *_content, void (*_init_function)(), void (*_loop_function)(), void (*_exit_function)(), astra_list_item_icon_t icon);
 //正确用法：astra_push_item_to_list(astra_get_root_list(), astra_new_user_item(...));
 
 //此种方法合理且安全，本质是将user item类转换为了基类，用于渲染


### PR DESCRIPTION
## Description:
This PR adds the ability to set custom iconography for each of the list items (e.g, two switch items can have different icons), and adds a new Button list item that runs an associated function when interacted with.

### **Breaking changes:**
The ```astra_new_list_item``` function requires an additional input for whichever icon it should use, ```default_icon``` maintains current functionality. This additional input is also extended to the derivative item types.

#### Example: ####

```
//astra_new_switch_item(char *_content, bool *_value, void (*_init_function)(), void (*_exit_function)(), astra_list_item_icon_t icon);

astra_new_switch_item("test switch", &switchValue, &initFunction, &exitFunction);
```

becomes 

```
astra_new_switch_item("test switch", &switchValue, &initFunction, &exitFunction, default_icon);
```

or any of the other icons in the ```astra_list_item_icon_t``` enum.

### **Button list item:**
The Button list item has the following initialization

```astra_new_button_item(char *_content, void (*_exit_function)(), astra_list_item_icon_t icon)```

Example initialization for power off button:
```astra_new_button_item("Power Off", &funcPowerOff, power_icon)```


### **New Icons:**
The rendering of icons for each list item has been moved to a new ```astra_draw_list_icon``` function.
This is the list of icons that can be rendered. Additional icons can be added by extending the enum and ```astra_draw_list_icon``` function.

```
typedef enum {
    default_icon,
    list_icon,
    switch_icon,
    plus_icon,
    user_icon,
    slider_icon,
    flag_icon,
    power_icon,
} astra_list_item_icon_t;
```

```default_icon``` is only used for initialization purposes